### PR TITLE
Version 1.0.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,9 +2,22 @@
 Plugin: Easy Support Videos
 Author: Slocum Design Studio
 Author URI: https://slocumstudio.com/
-Current Version: 1.0.0
+Current Version: 1.0.1
 ==========================================
 
+
+1.0.1 // November 18 2016
+-------------------------
+- Added logic to only create/output nonce fields if the current user can edit Easy Support Videos videos
+- Transitioned sidebar items to templates
+- Added Easy_Support_Videos_View JavaScript BackboneJS view to global instances scope
+- Added videos_el_selector parameter to Easy_Support_Videos_View
+- Added jQuery triggers after AJAX requests
+- Added page title parameter to Easy_Support_Videos_Post_Types
+- Added query arguments parameter to Easy_Support_Videos_Post_Types
+- Added filters to each parameter of add_menu_page()
+- Added actions to UnderscoreJS template for newly added videos (matches PHP logic)
+- Added actions before and after various AJAX function calls
 
 1.0.0 // October 17 2016
 ------------------------

--- a/easy-support-videos.php
+++ b/easy-support-videos.php
@@ -3,7 +3,7 @@
  * Plugin Name: Easy Support Videos
  * Plugin URI: https://www.slocumstudio.com/
  * Description: Easy Support Videos for embedding helpful tutorials, training videos, and screencasts in the Admin dashboard. Works with YouTube, Vimeo, Wistia, VideoPress, and more!
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: Slocum Studio
  * Author URI: http://www.slocumstudio.com/
  * Requires at least: 4.0
@@ -23,7 +23,7 @@ if ( ! class_exists( 'Easy_Support_Videos' ) ) {
 		/**
 		 * @var string
 		 */
-		public static $version = '1.0.0';
+		public static $version = '1.0.1';
 
 		/**
 		 * @var Easy_Support_Videos, Instance of the class

--- a/includes/admin/class-easy-support-videos-admin-views.php
+++ b/includes/admin/class-easy-support-videos-admin-views.php
@@ -81,6 +81,20 @@ if( ! class_exists( 'Easy_Support_Videos_Admin_Views' ) ) {
 		}
 
 		/**
+		 * This function renders the Easy Support Videos Sidebar Item Message template part.
+		 */
+		public static function sidebar_item_message() {
+			self::load_template( 'html-easy-support-videos-sidebar-item-message.php' );
+		}
+
+		/**
+		 * This function renders the Easy Support Videos Sidebar Item Rate template part.
+		 */
+		public static function sidebar_item_rate() {
+			self::load_template( 'html-easy-support-videos-sidebar-item-rate.php' );
+		}
+
+		/**
 		 * This function renders the Easy Support Videos Insert Video template part.
 		 */
 		public static function insert_video_template() {

--- a/includes/admin/views/html-easy-support-videos-insert-video.php
+++ b/includes/admin/views/html-easy-support-videos-insert-video.php
@@ -7,7 +7,7 @@
 	?>
 
 	<label for="easy-support-videos-insert-video-url"><?php _e( 'Add New Video:', 'easy-support-videos' ); ?></label>
-	<input id="easy-support-videos-insert-video-url" class="easy-support-videos-input easy-support-videos-insert-video-url regular-text" name="easy-support-videos-insert-video-url" type="text" value="" autocomplete="off" />
+	<input id="easy-support-videos-insert-video-url" class="regular-text easy-support-videos-input easy-support-videos-insert-video-url" name="easy-support-videos-insert-video-url" type="text" value="" autocomplete="off" />
 	<button id="easy-support-videos-insert-video-button" class="button button-secondary easy-support-videos-button easy-support-videos-insert-video-button"><?php _e( 'Add Video', 'easy-support-video' ); ?></button>
 	<span id="easy-support-videos-insert-video-spinner" class="spinner easy-support-videos-spinner easy-support-videos-insert-video-spinner"></span>
 

--- a/includes/admin/views/html-easy-support-videos-sidebar-item-message.php
+++ b/includes/admin/views/html-easy-support-videos-sidebar-item-message.php
@@ -1,0 +1,50 @@
+<?php
+	// Grab the Easy Support Videos options
+	$easy_support_videos_options = Easy_Support_Videos_Options::get_options();
+?>
+
+<?php do_action( 'easy_support_videos_sidebar_item_message_before' ); ?>
+
+<div class="easy-support-videos-sidebar-item easy-support-videos-sidebar-item-message <?php echo ( ! Easy_Support_Videos_Post_Types::current_user_can( Easy_Support_Videos_Post_Types::$easy_support_videos_post_type, 'publish_posts' ) && empty( $easy_support_videos_options['sidebar']['message'] ) ) ? 'empty' : ( ( ! Easy_Support_Videos_Post_Types::current_user_can( Easy_Support_Videos_Post_Types::$easy_support_videos_post_type, 'publish_posts' ) ) ? 'not-empty' : false ) ?>">
+	<?php do_action( 'easy_support_videos_sidebar_item_message_inner_before' ); ?>
+
+	<?php
+		// If the current user can publish Easy Support Videos
+		if ( Easy_Support_Videos_Post_Types::current_user_can( Easy_Support_Videos_Post_Types::$easy_support_videos_post_type, 'publish_posts' ) ) :
+	?>
+			<span class="easy-support-videos-sidebar-item-content">
+				<?php do_action( 'easy_support_videos_sidebar_item_message_content_before' ); ?>
+
+				<input id="easy-support-videos-sidebar-message-option-name" class="easy-support-videos-input easy-support-videos-hidden-input easy-support-videos-sidebar-message-option-name" name="easy-support-videos-sidebar-message-option-name" type="hidden" value="message" />
+				<input id="easy-support-videos-sidebar-message-option-group" class="easy-support-videos-input easy-support-videos-hidden-input easy-support-videos-sidebar-message-option-group" name="easy-support-videos-sidebar-message-option-group" type="hidden" value="sidebar" />
+				<label for="easy-support-videos-option-sidebar-message" class="screen-reader-text"><?php _e( 'Edit Sidebar Message:', 'easy-support-videos' ); ?></label>
+				<?php echo apply_filters( 'easy_support_videos_sidebar_item_message_textarea_markup', '<textarea id="easy-support-videos-option-sidebar-message" class="easy-support-videos-input easy-support-videos-textarea easy-support-videos-option-sidebar-message large-text" name="easy-support-videos-option-sidebar-message" cols="100" rows="10">' . esc_textarea( stripslashes( $easy_support_videos_options['sidebar']['message'] ) ) . '</textarea>', $easy_support_videos_options['sidebar']['message'], $easy_support_videos_options ); ?>
+				<span id="easy-support-videos-video-sidebar-message-spinner" class="spinner easy-support-videos-spinner easy-support-videos-video-spinner easy-support-videos-video-sidebar-message-spinner"></span>
+
+				<?php do_action( 'easy_support_videos_sidebar_item_message_content_after' ); ?>
+			</span>
+	<?php
+		// Otherwise the current user can view Easy Support Videos
+		else:
+	?>
+			<span class="easy-support-videos-sidebar-item-content">
+				<?php do_action( 'easy_support_videos_sidebar_item_message_content_before' ); ?>
+
+				<?php
+					// Apply the_content filter to the sidebar message
+					$easy_support_videos_options['sidebar']['message'] = apply_filters( 'the_content', $easy_support_videos_options['sidebar']['message'] );
+					$easy_support_videos_options['sidebar']['message'] = str_replace( ']]>', ']]&gt;', stripslashes( $easy_support_videos_options['sidebar']['message'] ) );
+
+					echo $easy_support_videos_options['sidebar']['message'];
+				?>
+
+				<?php do_action( 'easy_support_videos_sidebar_item_message_content_after' ); ?>
+			</span>
+	<?php
+		endif;
+	?>
+
+	<?php do_action( 'easy_support_videos_sidebar_item_message_inner_after' ); ?>
+</div>
+
+<?php do_action( 'easy_support_videos_sidebar_item_message_after' ); ?>

--- a/includes/admin/views/html-easy-support-videos-sidebar-item-rate.php
+++ b/includes/admin/views/html-easy-support-videos-sidebar-item-rate.php
@@ -1,0 +1,17 @@
+<?php do_action( 'easy_support_videos_sidebar_item_rate_before' ); ?>
+
+<div class="easy-support-videos-sidebar-item easy-support-videos-sidebar-item-rate">
+	<?php do_action( 'easy_support_videos_sidebar_item_rate_inner_before' ); ?>
+
+	<span class="easy-support-videos-sidebar-item-content">
+		<?php do_action( 'easy_support_videos_sidebar_item_rate_content_before' ); ?>
+
+		<?php printf( __( 'Love this plugin? Please rate <strong>Easy Support Videos</strong> <a href="%1$s" target="_blank">&#9733;&#9733;&#9733;&#9733;&#9733;</a> on <a href="%1$s" target="_blank">WordPress.org</a>.', 'easy-support-videos' ), 'https://wordpress.org/support/plugin/easy-support-videos/reviews/?filter=5' ); ?>
+
+		<?php do_action( 'easy_support_videos_sidebar_item_rate_content_after' ); ?>
+	</span>
+
+	<?php do_action( 'easy_support_videos_sidebar_item_rate_inner_after' ); ?>
+</div>
+
+<?php do_action( 'easy_support_videos_sidebar_item_rate_after' ); ?>

--- a/includes/admin/views/html-easy-support-videos-sidebar.php
+++ b/includes/admin/views/html-easy-support-videos-sidebar.php
@@ -7,52 +7,22 @@
 	<div id="easy-support-videos-sidebar-inner" class="easy-support-videos-sidebar-inner">
 		<?php do_action( 'easy_support_videos_sidebar_before' ); ?>
 
-		<div class="easy-support-videos-sidebar-item easy-support-videos-sidebar-item-message <?php echo ( ! Easy_Support_Videos_Post_Types::current_user_can( Easy_Support_Videos_Post_Types::$easy_support_videos_post_type, 'publish_posts' ) && empty( $easy_support_videos_options['sidebar']['message'] ) ) ? 'empty' : ( ( ! Easy_Support_Videos_Post_Types::current_user_can( Easy_Support_Videos_Post_Types::$easy_support_videos_post_type, 'publish_posts' ) ) ? 'not-empty' : false ) ?>">
-			<?php
-				// If the current user can publish Easy Support Videos
-				if ( Easy_Support_Videos_Post_Types::current_user_can( Easy_Support_Videos_Post_Types::$easy_support_videos_post_type, 'publish_posts' ) ) :
-			?>
-					<span class="easy-support-videos-sidebar-item-content">
-						<input id="easy-support-videos-sidebar-message-option-name" class="easy-support-videos-input easy-support-videos-hidden-input easy-support-videos-sidebar-message-option-name" name="easy-support-videos-sidebar-message-option-name" type="hidden" value="message" />
-						<input id="easy-support-videos-sidebar-message-option-group" class="easy-support-videos-input easy-support-videos-hidden-input easy-support-videos-sidebar-message-option-group" name="easy-support-videos-sidebar-message-option-group" type="hidden" value="sidebar" />
-						<label for="easy-support-videos-option-sidebar-message" class="screen-reader-text"><?php _e( 'Edit Sidebar Message:', 'easy-support-videos' ); ?></label>
-						<textarea id="easy-support-videos-option-sidebar-message" class="easy-support-videos-input easy-support-videos-textarea easy-support-videos-option-sidebar-message large-text" name="easy-support-videos-option-sidebar-message" cols="100" rows="10"><?php echo esc_textarea( stripslashes( $easy_support_videos_options['sidebar']['message'] ) ); ?></textarea>
-						<span id="easy-support-videos-video-sidebar-message-spinner" class="spinner easy-support-videos-spinner easy-support-videos-video-spinner easy-support-videos-video-sidebar-message-spinner"></span>
-					</span>
-			<?php
-				// Otherwise the current user can view Easy Support Videos
-				else:
-			?>
-					<span class="easy-support-videos-sidebar-item-content">
-						<?php
-							// Apply the_content filter to the sidebar message
-							$easy_support_videos_options['sidebar']['message'] = apply_filters( 'the_content', $easy_support_videos_options['sidebar']['message'] );
-							$easy_support_videos_options['sidebar']['message'] = str_replace( ']]>', ']]&gt;', stripslashes( $easy_support_videos_options['sidebar']['message'] ) );
-
-							echo $easy_support_videos_options['sidebar']['message'];
-						?>
-					</span>
-			<?php
-				endif;
-			?>
-		</div>
+		<?php
+			/*
+			 * Sidebar Item - Message
+			 */
+			Easy_Support_Videos_Admin_Views::sidebar_item_message();
+		?>
 
 		<?php do_action( 'easy_support_videos_sidebar_after' ); ?>
 	</div>
 
 	<?php
 		if ( $show_easy_support_videos_rate_item = apply_filters( 'easy_support_videos_sidebar_show_rate_item', true ) ) :
-	?>
-		<?php do_action( 'easy_support_videos_sidebar_item_rate_before' ); ?>
-
-		<div class="easy-support-videos-sidebar-item easy-support-videos-sidebar-item-rate">
-			<span class="easy-support-videos-sidebar-item-content">
-				<?php printf( __( 'Love this plugin? Please rate <strong>Easy Support Videos</strong> <a href="%1$s" target="_blank">&#9733;&#9733;&#9733;&#9733;&#9733;</a> on <a href="%1$s" target="_blank">WordPress.org</a>.', 'easy-support-videos' ), 'https://wordpress.org/support/plugin/easy-support-videos/reviews/?filter=5' ); ?>
-			</span>
-		</div>
-
-		<?php do_action( 'easy_support_videos_sidebar_item_rate_after' ); ?>
-	<?php
+			/*
+			 * Sidebar Item - Rate
+			 */
+			Easy_Support_Videos_Admin_Views::sidebar_item_rate();
 		endif;
 	?>
 </div>

--- a/includes/admin/views/html-easy-support-videos-videos.php
+++ b/includes/admin/views/html-easy-support-videos-videos.php
@@ -9,21 +9,17 @@
 	<?php do_action( 'easy_support_videos_inner_before' ); ?>
 
 	<?php
-		// Add an edit nonce field
-		wp_nonce_field( 'easy_support_videos_edit', 'easy_support_videos_nonce_edit' );
+		// If the current user can edit Easy Support Videos
+		if ( $current_user_can_edit_easy_support_videos ) {
+			// Add an edit nonce field
+			wp_nonce_field( 'easy_support_videos_edit', 'easy_support_videos_nonce_edit' );
 
-		// Add a delete nonce field
-		wp_nonce_field( 'easy_support_videos_delete', 'easy_support_videos_nonce_delete' );
+			// Add a delete nonce field
+			wp_nonce_field( 'easy_support_videos_delete', 'easy_support_videos_nonce_delete' );
+		}
 
 		// Find Easy Support Videos
-		$easy_support_videos = new WP_Query( apply_filters( 'easy_support_videos_videos_args', array(
-			'post_type' => Easy_Support_Videos_Post_Types::$easy_support_videos_post_type,
-			'posts_per_page' => wp_count_posts( Easy_Support_Videos_Post_Types::$easy_support_videos_post_type )->publish,
-			'orderby' => array(
-				'menu_order' => 'ASC',
-				'date' => 'DESC'
-			)
-		) ) );
+		$easy_support_videos = new WP_Query( apply_filters( 'easy_support_videos_videos_args', Easy_Support_Videos_Post_Types::$query_args ) );
 
 		// If we have Easy Support Videos
 		if ( $easy_support_videos->have_posts() ) :
@@ -37,7 +33,7 @@
 
 				do_action( 'easy_support_videos_video_before', $post );
 	?>
-			<div <?php post_class( ( $current_user_can_edit_easy_support_videos ) ? 'easy-support-video easy-support-video-can-edit easy-support-video-' . $post_id : 'easy-support-video easy-support-video-' . $post_id ); ?> data-post-id="<?php echo $post_id; ?>">
+			<div <?php post_class( ( $current_user_can_edit_easy_support_videos ) ? 'easy-support-video easy-support-video-can-edit easy-support-video-' . $post_id : 'easy-support-video easy-support-video-' . $post_id ); ?> data-post-id="<?php echo $post_id; ?>" <?php do_action( 'easy_support_videos_video_data_attributes', $post ); // TODO: Change this to a function with a filter instead of an action like Conductor? ?>>
 				<?php do_action( 'easy_support_videos_video_inner_before', $post ); ?>
 
 				<?php
@@ -67,12 +63,12 @@
 							$post_id = ( int ) get_the_ID();
 					?>
 							<label for="easy-support-videos-video-<?php echo $post_id; ?>-title" class="screen-reader-text"><?php _e( 'Video Title:', 'easy-support-videos' ); ?></label>
-							<input id="easy-support-videos-video-<?php echo $post_id; ?>-title" class="easy-support-videos-input easy-support-videos-video-title easy-support-videos-video-<?php echo $post_id; ?>-title regular-text" name="easy-support-videos-video-<?php echo $post_id; ?>-title" type="text" value="<?php echo esc_attr( get_the_title() ); ?>" autocomplete="off" />
+							<input id="easy-support-videos-video-<?php echo $post_id; ?>-title" class="regular-text easy-support-videos-input easy-support-videos-video-title easy-support-videos-video-<?php echo $post_id; ?>-title" name="easy-support-videos-video-<?php echo $post_id; ?>-title" type="text" value="<?php echo esc_attr( get_the_title() ); ?>" autocomplete="off" />
 							<span id="easy-support-videos-video-<?php echo $post_id; ?>-title-spinner" class="spinner easy-support-videos-spinner easy-support-videos-video-title-spinner easy-support-videos-video-<?php echo $post_id; ?>-title-spinner"></span>
 							<a href="#" class="easy-support-videos-video-delete" title="<?php _e( 'Delete Video', 'easy-support-videos' ); ?>">
 								<span class="dashicons dashicons-dismiss"></span>
 							</a>
-							<input id="easy-support-videos-video-<?php echo $post_id; ?>-id" class="easy-support-videos-input easy-support-videos-input-hiden easy-support-videos-video-id easy-support-videos-post-id easy-support-videos-video-<?php echo $post_id; ?>-id" type="hidden" value="<?php echo $post_id; ?>" />
+							<input id="easy-support-videos-video-<?php echo $post_id; ?>-id" class="easy-support-videos-input easy-support-videos-input-hidden easy-support-videos-video-id easy-support-videos-post-id easy-support-videos-video-<?php echo $post_id; ?>-id" type="hidden" value="<?php echo $post_id; ?>" />
 					<?php
 						else:
 							the_title();

--- a/includes/admin/views/js-easy-support-videos-video.php
+++ b/includes/admin/views/js-easy-support-videos-video.php
@@ -7,22 +7,34 @@
 <script type="text/template" id="tmpl-easy-support-videos-video">
 	<?php do_action( 'easy_support_videos_video_before', array() ); ?>
 
-	<div class="easy-support-video easy-support-video-can-edit easy-support-video-{{ data.post_id }}" data-post-id="{{ data.post_id }}">
+	<div class="easy-support-video easy-support-video-can-edit easy-support-video-{{ data.post_id }}" data-post-id="{{ data.post_id }}" <?php do_action( 'easy_support_videos_video_data_attributes', array() ); // TODO: Change this to a function with a filter instead of an action? ?>>
+		<?php do_action( 'easy_support_videos_video_inner_before', array() ); ?>
+
 		<span id="easy-support-videos-video-{{ data.post_id }}-spinner" class="spinner easy-support-videos-spinner easy-support-videos-video-spinner easy-support-videos-video-{{ data.post_id }}-spinner"></span>
 
 		<div class="easy-support-video-content">
+			<?php do_action( 'easy_support_videos_video_content_before', array() ); ?>
+
 			{{{ data.html }}}
+
+			<?php do_action( 'easy_support_videos_video_content_after', array() ); ?>
 		</div>
 
 		<div class="easy-support-video-title easy-support-video-can-edit-title">
+			<?php do_action( 'easy_support_videos_video_title_before', array() ); ?>
+
 			<label for="easy-support-videos-video-{{ data.post_id }}-title" class="screen-reader-text"><?php _e( 'Video Title:', 'easy-support-videos' ); ?></label>
-			<input id="easy-support-videos-video-{{ data.post_id }}-title" class="easy-support-videos-input easy-support-videos-video-title easy-support-videos-video-{{ data.post_id }}-title regular-text" name="easy-support-videos-video-{{ data.post_id }}-title" type="text" value="{{ data.title }}" autocomplete="off" />
+			<input id="easy-support-videos-video-{{ data.post_id }}-title" class="regular-text easy-support-videos-input easy-support-videos-video-title easy-support-videos-video-{{ data.post_id }}-title" name="easy-support-videos-video-{{ data.post_id }}-title" type="text" value="{{ data.title }}" autocomplete="off" />
 			<span id="easy-support-videos-video-{{ data.post_id }}-title-spinner" class="spinner easy-support-videos-spinner easy-support-videos-video-title-spinner easy-support-videos-video-{{ data.post_id }}-title-spinner"></span>
 			<a href="#" class="easy-support-videos-video-delete" title="<?php _e( 'Delete Video', 'easy-support-videos' ); ?>">
 				<span class="dashicons dashicons-dismiss"></span>
 			</a>
 			<input id="easy-support-videos-video-{{ data.post_id }}-id" class="easy-support-videos-input easy-support-videos-input-hidden easy-support-videos-video-id easy-support-videos-post-id easy-support-videos-video-{{ data.post_id }}-id" type="hidden" value="{{ data.post_id }}" />
+
+			<?php do_action( 'easy_support_videos_video_title_after', array() ); ?>
 		</div>
+
+		<?php do_action( 'easy_support_videos_video_inner_after', array() ); ?>
 	</div>
 
 	<?php do_action( 'easy_support_videos_video_after', array() ); ?>

--- a/includes/class-easy-support-videos-options.php
+++ b/includes/class-easy-support-videos-options.php
@@ -4,7 +4,7 @@
  *
  * @class Easy_Support_Videos_Options
  * @author Slocum Studio
- * @version 1.0.0
+ * @version 1.0.1
  * @since 1.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! class_exists( 'Easy_Support_Videos_Options' ) ) {
 		/**
 		 * @var string
 		 */
-		public $version = '1.0.0';
+		public $version = '1.0.1';
 
 		/**
 		 * @var string
@@ -48,6 +48,8 @@ if ( ! class_exists( 'Easy_Support_Videos_Options' ) ) {
 			// Hooks
 			register_activation_hook( Easy_Support_Videos::plugin_file(), array( $this, 'activate' ) ); // Activate
 			add_filter( 'sanitize_option_' . self::$option_name, array( $this, 'sanitize_option' ) ); // Sanitize Easy Support Videos Option
+
+			// AJAX
 			add_action( 'wp_ajax_easy_support_videos_save_option', array( $this, 'wp_ajax_easy_support_videos_save_option' ) ); // Easy Support Videos Save Option
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:
 Tags: videos, support, youtube, vimeo, wistia, admin help
 Requires at least: 4.3
 Tested up to: 4.6.1
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -14,6 +14,8 @@ Easy Support Videos for embedding helpful tutorials, training videos, and screen
 == Description ==
 
 Easy Support Videos is great for WordPress consultants, trainers, and product owners to embed compatible oEmbed video into the admin dashboard of a WordPress website. Simply install the plugin, and copy/paste the video link into the admin page, and Easy Support Videos will elegantly display a list of videos for your user.
+
+https://www.youtube.com/watch?v=SG0F_N3qS28
 
 Admins can control who can see the videos, and edit/remove videos, by setting the available role options within Easy Support Video settings. You can also leave a custom note on the video page sidebar, offering further instructions or helpful tips.
 
@@ -58,10 +60,24 @@ In the settings page of Easy Support Videos, you can control who can edit and vi
 
 == Screenshots ==
 
+1. Easy Support Videos
+2. Easy Support Videos Options
 
 == Changelog ==
 
-= 1.0.0 // October 14 2016 =
+= 1.0.1 // November 18 2016 =
+* Added logic to only create/output nonce fields if the current user can edit Easy Support Videos videos
+* Transitioned sidebar items to templates
+* Added Easy_Support_Videos_View JavaScript BackboneJS view to global instances scope
+* Added videos_el_selector parameter to Easy_Support_Videos_View
+* Added jQuery triggers after AJAX requests
+* Added page title parameter to Easy_Support_Videos_Post_Types
+* Added query arguments parameter to Easy_Support_Videos_Post_Types
+* Added filters to each parameter of add_menu_page()
+* Added actions to UnderscoreJS template for newly added videos (matches PHP logic)
+* Added actions before and after various AJAX function calls
+
+= 1.0.0 // October 17 2016 =
 * Initial Release
 
 


### PR DESCRIPTION
- Added logic to only create/output nonce fields if the current user can
edit Easy Support Videos videos
- Transitioned sidebar items to templates
- Added Easy_Support_Videos_View JavaScript BackboneJS view to global
instances scope
- Added videos_el_selector parameter to Easy_Support_Videos_View
- Added jQuery triggers after AJAX requests
- Added page title parameter to Easy_Support_Videos_Post_Types
- Added query arguments parameter to Easy_Support_Videos_Post_Types
- Added filters to each parameter of add_menu_page()
- Added actions to UnderscoreJS template for newly added videos (matches
PHP logic)
- Added actions before and after various AJAX function calls