### PR TITLE
Version 1.0.4

### DIFF
--- a/assets/css/easy-support-videos-admin.css
+++ b/assets/css/easy-support-videos-admin.css
@@ -68,6 +68,11 @@
 	-ms-flex-pack: end;
 }
 
+/* WordPress 4.8 added flexbox styles to column elements in the about wrap, so we'll set the columns to display as block level elements */
+.easy-support-videos-flex [class$="-col"] {
+	display: block;
+}
+
 .easy-support-videos-flex .easy-support-videos-col {
 	width: 100%;
 	position: relative;
@@ -193,6 +198,7 @@
  * Videos
  */
 #easy-support-videos-videos {
+	width: 100%;
 	padding: 2rem 0;
 }
 
@@ -201,6 +207,7 @@
 }
 
 #easy-support-videos-videos .easy-support-video {
+	width: 100%;
 	padding: 1rem 0;
 	position: relative;
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,9 +2,22 @@
 Plugin: Easy Support Videos
 Author: Slocum Design Studio
 Author URI: https://slocumthemes.com/
-Current Version: 1.0.3
+Current Version: 1.0.4
 ==========================================
 
+
+1.0.4 // January 17 2018
+------------------------
+- Fixed a bug where videos were not rendered correctly in WordPress 4.8+
+- Adjusted AJAX logic to ensure duplicate requests were not executed (only the last - most
+  recent - request is executed)
+- Adjusted AJAX logic to ensure individual spinner icons were displayed/hidden correctly
+- Adjusted AJAX logic to ensure messages were not displayed when an AJAX request was aborted
+- Added logic to trigger "esv-ajax-processing" JavaScript event when the AJAX queue is processing
+- Added logic to load plugin text domain via load_plugin_textdomain()
+- Added "easy_support_videos_current_user_can" filter to all Easy_Support_Videos_Post_Types::current_user_can()
+  conditional cases
+- Introduce POT file
 
 1.0.3 // February 20 2017
 -------------------------

--- a/easy-support-videos.php
+++ b/easy-support-videos.php
@@ -3,11 +3,11 @@
  * Plugin Name: Easy Support Videos
  * Plugin URI: https://www.slocumstudio.com/
  * Description: Easy Support Videos for embedding helpful tutorials, training videos, and screencasts in the Admin dashboard. Works with YouTube, Vimeo, Wistia, VideoPress, and more!
- * Version: 1.0.3
+ * Version: 1.0.4
  * Author: Slocum Studio
  * Author URI: http://www.slocumstudio.com/
- * Requires at least: 4.0
- * Tested up to: 4.7.2
+ * Requires at least: 4.3
+ * Tested up to: 4.9.1
  * License: GPL2+
  *
  * Text Domain: easy-support-videos
@@ -23,7 +23,7 @@ if ( ! class_exists( 'Easy_Support_Videos' ) ) {
 		/**
 		 * @var string
 		 */
-		public static $version = '1.0.3';
+		public static $version = '1.0.4';
 
 		/**
 		 * @var Easy_Support_Videos, Instance of the class
@@ -48,6 +48,9 @@ if ( ! class_exists( 'Easy_Support_Videos' ) ) {
 		function __construct() {
 			// Load required assets
 			$this->includes();
+
+			// Hooks
+			add_action( 'plugins_loaded', array( $this, 'plugins_loaded' ) ); // Plugins Loaded
 		}
 
 		/**
@@ -61,6 +64,14 @@ if ( ! class_exists( 'Easy_Support_Videos' ) ) {
 				include_once 'includes/admin/class-easy-support-videos-admin-options.php'; // Easy Support Videos Admin Options
 				include_once 'includes/class-easy-support-videos-upgrade.php'; // Easy Support Videos Upgrade
 			}
+		}
+
+		/**
+		 * This function runs when plugins are loaded.
+		 */
+		public function plugins_loaded() {
+			// Load the Easy Support Videos text domain
+			load_plugin_textdomain( 'easy-support-videos', false, basename( self::plugin_dir() ) . '/languages/' );
 		}
 
 

--- a/includes/admin/views/html-easy-support-videos-insert-video.php
+++ b/includes/admin/views/html-easy-support-videos-insert-video.php
@@ -8,8 +8,8 @@
 
 	<label for="easy-support-videos-insert-video-url"><?php _e( 'Add New Video:', 'easy-support-videos' ); ?></label>
 	<input id="easy-support-videos-insert-video-url" class="regular-text easy-support-videos-input easy-support-videos-insert-video-url" name="easy-support-videos-insert-video-url" type="text" value="" autocomplete="off" />
-	<button id="easy-support-videos-insert-video-button" class="button button-secondary easy-support-videos-button easy-support-videos-insert-video-button"><?php _e( 'Add Video', 'easy-support-video' ); ?></button>
-	<span id="easy-support-videos-insert-video-spinner" class="spinner easy-support-videos-spinner easy-support-videos-insert-video-spinner"></span>
+	<button id="easy-support-videos-insert-video-button" class="button button-secondary easy-support-videos-button easy-support-videos-insert-video-button"><?php _e( 'Add Video', 'easy-support-videos' ); ?></button>
+	<span id="easy-support-videos-insert-video-spinner" class="spinner easy-support-videos-spinner easy-support-videos-insert-video-spinner" data-type="video" data-event="insert"></span>
 
 	<div id="easy-support-videos-insert-video-description" class="easy-support-videos-insert-video-description">
 		<p class="description easy-support-videos-description"><?php printf( __( 'To add a video to the library, paste a URL from any %1$s and "Add Video" or press enter.', 'easy-support-videos' ), sprintf( '<a href="%1$s" target="_blank">%2$s</a>', esc_url( 'https://codex.wordpress.org/Embeds' ), __( 'oEmbed video provider', 'easy-support-videos' ) ) ); ?></p>

--- a/includes/admin/views/html-easy-support-videos-sidebar-item-message.php
+++ b/includes/admin/views/html-easy-support-videos-sidebar-item-message.php
@@ -12,17 +12,17 @@
 		// If the current user can publish Easy Support Videos
 		if ( Easy_Support_Videos_Post_Types::current_user_can( Easy_Support_Videos_Post_Types::$easy_support_videos_post_type, 'publish_posts' ) ) :
 	?>
-			<span class="easy-support-videos-sidebar-item-content">
+			<div class="easy-support-videos-sidebar-item-content">
 				<?php do_action( 'easy_support_videos_sidebar_item_message_content_before' ); ?>
 
 				<input id="easy-support-videos-sidebar-message-option-name" class="easy-support-videos-input easy-support-videos-hidden-input easy-support-videos-sidebar-message-option-name" name="easy-support-videos-sidebar-message-option-name" type="hidden" value="message" />
 				<input id="easy-support-videos-sidebar-message-option-group" class="easy-support-videos-input easy-support-videos-hidden-input easy-support-videos-sidebar-message-option-group" name="easy-support-videos-sidebar-message-option-group" type="hidden" value="sidebar" />
 				<label for="easy-support-videos-option-sidebar-message" class="screen-reader-text"><?php _e( 'Edit Sidebar Message:', 'easy-support-videos' ); ?></label>
 				<?php echo apply_filters( 'easy_support_videos_sidebar_item_message_textarea_markup', '<textarea id="easy-support-videos-option-sidebar-message" class="easy-support-videos-input easy-support-videos-textarea easy-support-videos-option-sidebar-message large-text" name="easy-support-videos-option-sidebar-message" cols="100" rows="10">' . esc_textarea( stripslashes( $easy_support_videos_options['sidebar']['message'] ) ) . '</textarea>', $easy_support_videos_options['sidebar']['message'], $easy_support_videos_options ); ?>
-				<span id="easy-support-videos-video-sidebar-message-spinner" class="spinner easy-support-videos-spinner easy-support-videos-video-spinner easy-support-videos-video-sidebar-message-spinner"></span>
+				<span id="easy-support-videos-video-sidebar-message-spinner" class="spinner easy-support-videos-spinner easy-support-videos-video-spinner easy-support-videos-video-sidebar-message-spinner" data-type="option" data-option-group="sidebar" data-option-name="message"></span>
 
 				<?php do_action( 'easy_support_videos_sidebar_item_message_content_after' ); ?>
-			</span>
+			</div>
 	<?php
 		// Otherwise the current user can view Easy Support Videos
 		else:

--- a/includes/admin/views/html-easy-support-videos-videos.php
+++ b/includes/admin/views/html-easy-support-videos-videos.php
@@ -40,7 +40,7 @@
 					// If the current user can edit Easy Support Videos
 					if ( $current_user_can_edit_easy_support_videos ) :
 				?>
-						<span id="easy-support-videos-video-<?php echo $post_id; ?>-spinner" class="spinner easy-support-videos-spinner easy-support-videos-video-spinner easy-support-videos-video-<?php echo $post_id; ?>-spinner"></span>
+						<span id="easy-support-videos-video-<?php echo $post_id; ?>-spinner" class="spinner easy-support-videos-spinner easy-support-videos-video-spinner easy-support-videos-video-<?php echo $post_id; ?>-spinner" data-type="video" data-post-id="<?php echo $post_id; ?>" data-event="video"></span>
 				<?php
 					endif;
 				?>
@@ -64,7 +64,7 @@
 					?>
 							<label for="easy-support-videos-video-<?php echo $post_id; ?>-title" class="screen-reader-text"><?php _e( 'Video Title:', 'easy-support-videos' ); ?></label>
 							<input id="easy-support-videos-video-<?php echo $post_id; ?>-title" class="regular-text easy-support-videos-input easy-support-videos-video-title easy-support-videos-video-<?php echo $post_id; ?>-title" name="easy-support-videos-video-<?php echo $post_id; ?>-title" type="text" value="<?php echo esc_attr( wp_unslash( get_the_title() ) ); ?>" autocomplete="off" />
-							<span id="easy-support-videos-video-<?php echo $post_id; ?>-title-spinner" class="spinner easy-support-videos-spinner easy-support-videos-video-title-spinner easy-support-videos-video-<?php echo $post_id; ?>-title-spinner"></span>
+							<span id="easy-support-videos-video-<?php echo $post_id; ?>-title-spinner" class="spinner easy-support-videos-spinner easy-support-videos-video-title-spinner easy-support-videos-video-<?php echo $post_id; ?>-title-spinner" data-type="video" data-post-id="<?php echo $post_id; ?>" data-event="edit"></span>
 							<a href="#" class="easy-support-videos-video-delete" title="<?php _e( 'Delete Video', 'easy-support-videos' ); ?>">
 								<span class="dashicons dashicons-dismiss"></span>
 							</a>

--- a/includes/admin/views/js-easy-support-videos-video.php
+++ b/includes/admin/views/js-easy-support-videos-video.php
@@ -10,7 +10,7 @@
 	<div class="easy-support-video easy-support-video-can-edit easy-support-video-{{ data.post_id }}" data-post-id="{{ data.post_id }}" <?php do_action( 'easy_support_videos_video_data_attributes', array() ); // TODO: Change this to a function with a filter instead of an action? ?>>
 		<?php do_action( 'easy_support_videos_video_inner_before', array() ); ?>
 
-		<span id="easy-support-videos-video-{{ data.post_id }}-spinner" class="spinner easy-support-videos-spinner easy-support-videos-video-spinner easy-support-videos-video-{{ data.post_id }}-spinner"></span>
+		<span id="easy-support-videos-video-{{ data.post_id }}-spinner" class="spinner easy-support-videos-spinner easy-support-videos-video-spinner easy-support-videos-video-{{ data.post_id }}-spinner" data-type="video" data-post-id="{{ data.post_id }}" data-event="video"></span>
 
 		<div class="easy-support-video-content">
 			<?php do_action( 'easy_support_videos_video_content_before', array() ); ?>
@@ -25,7 +25,7 @@
 
 			<label for="easy-support-videos-video-{{ data.post_id }}-title" class="screen-reader-text"><?php _e( 'Video Title:', 'easy-support-videos' ); ?></label>
 			<input id="easy-support-videos-video-{{ data.post_id }}-title" class="regular-text easy-support-videos-input easy-support-videos-video-title easy-support-videos-video-{{ data.post_id }}-title" name="easy-support-videos-video-{{ data.post_id }}-title" type="text" value="{{ data.title }}" autocomplete="off" />
-			<span id="easy-support-videos-video-{{ data.post_id }}-title-spinner" class="spinner easy-support-videos-spinner easy-support-videos-video-title-spinner easy-support-videos-video-{{ data.post_id }}-title-spinner"></span>
+			<span id="easy-support-videos-video-{{ data.post_id }}-title-spinner" class="spinner easy-support-videos-spinner easy-support-videos-video-title-spinner easy-support-videos-video-{{ data.post_id }}-title-spinner" data-type="video" data-post-id="{{ data.post_id }}" data-event="edit"></span>
 			<a href="#" class="easy-support-videos-video-delete" title="<?php _e( 'Delete Video', 'easy-support-videos' ); ?>">
 				<span class="dashicons dashicons-dismiss"></span>
 			</a>

--- a/includes/class-easy-support-videos-options.php
+++ b/includes/class-easy-support-videos-options.php
@@ -4,7 +4,7 @@
  *
  * @class Easy_Support_Videos_Options
  * @author Slocum Studio
- * @version 1.0.3
+ * @version 1.0.4
  * @since 1.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! class_exists( 'Easy_Support_Videos_Options' ) ) {
 		/**
 		 * @var string
 		 */
-		public $version = '1.0.3';
+		public $version = '1.0.4';
 
 		/**
 		 * @var string
@@ -290,6 +290,9 @@ if ( ! class_exists( 'Easy_Support_Videos_Options' ) ) {
 			// Update the status data
 			$status['message'] = $message;
 			$status['value'] = ( $sanitized_value ) ? $sanitized_value : $value;
+			$status['type'] = 'option';
+			$status['option_group'] = $option_group;
+			$status['option_name'] = $option_name;
 			$status = apply_filters( 'wp_ajax_easy_support_videos_save_option_success_status', $status, $message, $sanitized_value, $value, $option_name, $option_group, $easy_support_videos_options, $this );
 
 			// Success
@@ -373,7 +376,7 @@ if ( ! class_exists( 'Easy_Support_Videos_Options' ) ) {
 
 			$filtered = wp_check_invalid_utf8( $str );
 
-			if ( strpos( $filtered, '<') !== false ) {
+			if ( strpos( $filtered, '<' ) !== false ) {
 				$filtered = wp_pre_kses_less_than( $filtered );
 				$filtered = wp_strip_all_tags( $filtered );
 			}
@@ -388,7 +391,7 @@ if ( ! class_exists( 'Easy_Support_Videos_Options' ) ) {
 
 			if ( $found )
 				// Strip out the whitespace that may now exist after removing the octets
-				$filtered = trim( preg_replace( '/ +/', ' ', $filtered) );
+				$filtered = trim( preg_replace( '/ +/', ' ', $filtered ) );
 
 			return $filtered;
 		}

--- a/includes/class-easy-support-videos-post-types.php
+++ b/includes/class-easy-support-videos-post-types.php
@@ -3,7 +3,7 @@
  * Easy Support Videos Post Types
  *
  * @class Easy_Support_Videos_Post_Types
- * @version 1.0.3
+ * @version 1.0.4
  * @since 1.0.0
  */
 
@@ -16,7 +16,7 @@ if ( ! class_exists( 'Easy_Support_Videos_Post_Types' ) ) {
 		/**
 		 * @var string
 		 */
-		public static $version = '1.0.3';
+		public static $version = '1.0.4';
 
 		/**
 		 * @var string
@@ -344,6 +344,8 @@ if ( ! class_exists( 'Easy_Support_Videos_Post_Types' ) ) {
 			$status['title'] = $title;
 			$status['html'] = $html;
 			$status['message'] = __( 'Video added to library', 'easy-support-videos' );
+			$status['type'] = 'video';
+			$status['event'] = 'insert';
 			$status = apply_filters( 'wp_ajax_easy_support_videos_insert_success_status', $status, $post_id, $title, $html, self::$easy_support_videos_post_type, $data, $provider, $wp_oembed, $this );
 
 			do_action( 'wp_ajax_easy_support_videos_insert_wp_send_json_success', $status, $post_id, $title, $html, self::$easy_support_videos_post_type, $data, $provider, $wp_oembed, $this );
@@ -421,6 +423,8 @@ if ( ! class_exists( 'Easy_Support_Videos_Post_Types' ) ) {
 			$status['post_id'] = $post_id;
 			$status['title'] = wp_unslash( $title );
 			$status['message'] = __( 'Video updated.', 'easy-support-videos' );
+			$status['type'] = 'video';
+			$status['event'] = 'edit';
 			$status = apply_filters( 'wp_ajax_easy_support_videos_edit_success_status', $status, $post_id, $title, $this );
 
 			do_action( 'wp_ajax_easy_support_videos_edit_wp_send_json_success', $status, $post_id, $title, $this );
@@ -484,6 +488,8 @@ if ( ! class_exists( 'Easy_Support_Videos_Post_Types' ) ) {
 			// Update the status data
 			$status['post_id'] = $post_id;
 			$status['message'] = __( 'Video removed from library.', 'easy-support-videos' );
+			$status['type'] = 'video';
+			$status['event'] = 'video'; // Show the video spinner
 			$status = apply_filters( 'wp_ajax_easy_support_videos_delete_success_status', $status, $post_id, $this );
 
 			do_action( 'wp_ajax_easy_support_videos_delete_wp_send_json_success', $status, $post, $post_id, $this );
@@ -533,11 +539,11 @@ if ( ! class_exists( 'Easy_Support_Videos_Post_Types' ) ) {
 		public static function current_user_can( $post_type, $capability ) {
 			// Bail if the post type or capability aren't set
 			if ( ! array_key_exists( $post_type, self::$post_type_capabilities ) || ! array_key_exists( $capability, self::$post_type_capabilities[$post_type] ) )
-				return false;
+				return apply_filters( 'easy_support_videos_current_user_can', false, $post_type, $capability, self::$post_type_capabilities );
 
 			// Return the cached version
 			if ( array_key_exists( $post_type, self::$current_user_can ) && array_key_exists( $capability, self::$current_user_can[$post_type] ) )
-				return self::$current_user_can[$post_type][$capability];
+				return apply_filters( 'easy_support_videos_current_user_can', self::$current_user_can[$post_type][$capability], $post_type, $capability, self::$post_type_capabilities );
 
 			// Determine if the current user has the capability
 			$current_user_can = current_user_can( self::$post_type_capabilities[$post_type][$capability] );

--- a/languages/easy-support-videos.pot
+++ b/languages/easy-support-videos.pot
@@ -1,0 +1,367 @@
+# Copyright (C) 2017 Easy Support Videos
+# This file is distributed under the same license as the Easy Support Videos package.
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Easy Support Videos 1.0.4\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/easy-support-"
+"videos\n"
+"POT-Creation-Date: 2017-11-06 15:49-0500\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2017-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"X-Generator: Poedit 2.0.2\n"
+
+#: includes/admin/class-easy-support-videos-admin-options.php:88
+msgid "Options"
+msgstr ""
+
+#: includes/admin/class-easy-support-videos-admin-options.php:111
+msgid "Roles"
+msgstr ""
+
+#: includes/admin/class-easy-support-videos-admin-options.php:112
+msgid "Edit Videos"
+msgstr ""
+
+#: includes/admin/class-easy-support-videos-admin-options.php:113
+msgid "View Videos"
+msgstr ""
+
+#: includes/admin/class-easy-support-videos-admin-options.php:116
+msgid "Uninstall"
+msgstr ""
+
+#: includes/admin/class-easy-support-videos-admin-options.php:117
+msgid "Uninstall Data"
+msgstr ""
+
+#: includes/admin/class-easy-support-videos-admin-options.php:133
+msgid "<a href=\"%1$s\" target=\"_blank\">%2$s</a>"
+msgstr ""
+
+#: includes/admin/class-easy-support-videos-admin-options.php:133
+msgid "Upgrade for video sorting, more tabs, and white label features."
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-insert-video.php:9
+msgid "Add New Video:"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-insert-video.php:11
+msgid "Add Video"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-insert-video.php:15
+msgid ""
+"To add a video to the library, paste a URL from any %1$s and \"Add Video\" "
+"or press enter."
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-insert-video.php:15
+msgid "oEmbed video provider"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-options-roles-edit-field.php:10
+#: includes/admin/views/html-easy-support-videos-options-roles-read-field.php:10
+msgid "Select a Role"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-options-roles-edit-field.php:11
+#: includes/admin/views/html-easy-support-videos-options-roles-read-field.php:11
+msgid "Administrator"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-options-roles-edit-field.php:12
+#: includes/admin/views/html-easy-support-videos-options-roles-read-field.php:12
+msgid "Editor"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-options-roles-edit-field.php:13
+#: includes/admin/views/html-easy-support-videos-options-roles-read-field.php:13
+msgid "Author"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-options-roles-edit-field.php:14
+#: includes/admin/views/html-easy-support-videos-options-roles-read-field.php:14
+msgid "Contributor"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-options-roles-edit-field.php:18
+msgid ""
+"Select the role which can edit Easy Support Videos. Please note: Roles "
+"inherit capabilities by default in WordPress. If the \"Contributor\" role is "
+"selected, every role that inherits Contributor capabilities will be able to "
+"edit Easy Support Videos."
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-options-roles-read-field.php:15
+msgid "Subscriber"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-options-roles-read-field.php:19
+msgid ""
+"Select the role which can view Easy Support Videos. Please note: Roles "
+"inherit capabilities by default in WordPress. If the \"Contributor\" role is "
+"selected, every role that inherits Contributor capabilities will be able to "
+"view Easy Support Videos."
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-options-roles-section.php:3
+msgid ""
+"Use these options to specify roles for various aspects of Easy Support "
+"Videos."
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-options-uninstall-data-field.php:9
+msgid "Yes"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-options-uninstall-data-field.php:9
+msgid "No"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-options-uninstall-data-field.php:13
+msgid "Should data be removed when uninstalling Easy Support Videos?"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-options-uninstall-section.php:3
+msgid ""
+"Use these options to specify which actions happen when uninstalling Easy "
+"Support Videos."
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-options.php:2
+msgid "Easy Support Videos Options"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-options.php:37
+msgid "Save Options"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-options.php:38
+msgid "Restore Defaults"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-page-title.php:3
+#: includes/class-easy-support-videos-post-types.php:110
+#: includes/class-easy-support-videos-post-types.php:159
+#: includes/class-easy-support-videos-post-types.php:163
+#: includes/class-easy-support-videos-post-types.php:210
+msgid "Support Videos"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-sidebar-item-message.php:20
+msgid "Edit Sidebar Message:"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-sidebar-item-rate.php:9
+msgid ""
+"Love this plugin? Please rate <strong>Easy Support Videos</strong> <a href="
+"\"%1$s\" target=\"_blank\">&#9733;&#9733;&#9733;&#9733;&#9733;</a> on <a "
+"href=\"%1$s\" target=\"_blank\">WordPress.org</a>."
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-videos.php:65
+#: includes/admin/views/js-easy-support-videos-video.php:26
+msgid "Video Title:"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-videos.php:68
+#: includes/admin/views/js-easy-support-videos-video.php:29
+msgid "Delete Video"
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-videos.php:97
+msgid "Add videos above."
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos-videos.php:100
+msgid ""
+"Your support administrator has not added any videos. Please check again "
+"later."
+msgstr ""
+
+#: includes/admin/views/html-easy-support-videos.php:30
+msgid "Close Message"
+msgstr ""
+
+#: includes/class-easy-support-videos-options.php:193
+msgid "There was an error saving. Please try again."
+msgstr ""
+
+#: includes/class-easy-support-videos-options.php:203
+msgid ""
+"You do not have sufficient permissions for Easy Support Videos on this site."
+msgstr ""
+
+#: includes/class-easy-support-videos-options.php:247
+msgid "Saved."
+msgstr ""
+
+#: includes/class-easy-support-videos-options.php:266
+msgid "Sidebar message saved."
+msgstr ""
+
+#: includes/class-easy-support-videos-options.php:339
+msgid "Thanks for using Easy Support Videos. Click here to edit this message."
+msgstr ""
+
+#. Description of the plugin/theme
+#: includes/class-easy-support-videos-post-types.php:158
+msgid ""
+"Easy Support Videos for embedding helpful tutorials, training videos, and "
+"screencasts in the Admin dashboard. Works with YouTube, Vimeo, Wistia, "
+"VideoPress, and more!"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:161
+msgctxt "post type general name"
+msgid "Support Videos"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:162
+msgctxt "post type singular name"
+msgid "Support Video"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:164
+msgid "Support Video"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:165
+msgid "Parent:"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:166
+msgid "All Support Videos"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:167
+msgid "Add New Support Video"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:168
+msgid "Add New"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:169
+msgid "New Support Video"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:170
+msgid "Edit Support Video"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:171
+msgid "Update Support Video"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:172
+msgid "View Support Video"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:173
+msgid "No Support Videos found"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:174
+msgid "Not Support Videos found in Trash"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:175
+msgid "Insert into Support Video"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:176
+msgid "Uploaded to this Support Video"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:177
+msgid "Support Videos list"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:178
+msgid "Support Videos list navigation"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:179
+msgid "Filter Support Videos list"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:233
+msgid "Please enter a video URL."
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:234
+msgid "The video title cannot be empty."
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:263
+msgid "There was an error adding the video. Please try again."
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:273
+msgid ""
+"You do not have sufficient permissions to add Easy Support Videos to this "
+"site."
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:288
+msgid "The oEmbed provider isn't valid. Please try again."
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:300
+msgid "The URL provided was not associated with a video. Please try again."
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:346
+msgid "Video added to library"
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:365
+msgid "There was an error editing the video. Please try again."
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:375
+msgid ""
+"You do not have sufficient permissions to edit Easy Support Videos on this "
+"site."
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:425
+msgid "Video updated."
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:444
+msgid "There was an error deleting the video. Please try again."
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:454
+msgid ""
+"You do not have sufficient permissions to delete Easy Support Videos on this "
+"site."
+msgstr ""
+
+#: includes/class-easy-support-videos-post-types.php:490
+msgid "Video removed from library."
+msgstr ""
+
+#. Plugin Name of the plugin/theme
+msgid "Easy Support Videos"
+msgstr ""
+
+#. Plugin URI of the plugin/theme
+msgid "https://www.slocumstudio.com/"
+msgstr ""
+
+#. Author of the plugin/theme
+msgid "Slocum Studio"
+msgstr ""
+
+#. Author URI of the plugin/theme
+msgid "http://www.slocumstudio.com/"
+msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: slocumstudio
 Donate link:
 Tags: videos, support, youtube, vimeo, wistia, admin help, dashboard
 Requires at least: 4.3
-Tested up to: 4.7.2
-Stable tag: 1.0.3
+Tested up to: 4.9.1
+Stable tag: 1.0.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -73,6 +73,17 @@ In the settings page of Easy Support Videos, you can control who can edit and vi
 2. Easy Support Videos Options
 
 == Changelog ==
+
+= 1.0.4 // January 17 2018 =
+-------------------------
+* Fixed a bug where videos were not rendered correctly in WordPress 4.8+
+* Adjusted AJAX logic to ensure duplicate requests were not executed (only the last - most recent - request is executed)
+* Adjusted AJAX logic to ensure individual spinner icons were displayed/hidden correctly
+* Adjusted AJAX logic to ensure messages were not displayed when an AJAX request was aborted
+* Added logic to trigger "esv-ajax-processing" JavaScript event when the AJAX queue is processing
+* Added logic to load plugin text domain via load_plugin_textdomain()
+* Added "easy_support_videos_current_user_can" filter to all Easy_Support_Videos_Post_Types::current_user_can() conditional cases
+* Introduce POT file
 
 = 1.0.3 // February 20 2017 =
 -------------------------


### PR DESCRIPTION
- Fixed a bug where videos were not rendered correctly in WordPress 4.8+
- Adjusted AJAX logic to ensure duplicate requests were not executed
(only the last - most recent - request is executed)
- Adjusted AJAX logic to ensure individual spinner icons were
displayed/hidden correctly
- Adjusted AJAX logic to ensure messages were not displayed when an AJAX
request was aborted
- Added logic to trigger "esv-ajax-processing" JavaScript event when the
AJAX queue is processing
- Added logic to load plugin text domain via load_plugin_textdomain()
- Added "easy_support_videos_current_user_can" filter to all
Easy_Support_Videos_Post_Types::current_user_can() conditional cases
- Introduce POT file